### PR TITLE
Added a transactional consumer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "mockery/mockery": "^0.9.4",
         "league/event": "^2.1",
         "league/tactician": "^1.0",
-        "symfony/console": "^2.7|^3.0"
+        "symfony/console": "^2.7|^3.0",
+        "remi-san/transaction-manager": "^1.0"
     },
 
     "autoload": {
@@ -30,6 +31,7 @@
     "suggest": {
         "league/event": "Allows to deal with event within your application.",
         "league/tactician": "Allows to deal with command within your application.",
-        "symfony/console": "Allows to bootstrap a CLI command."
+        "symfony/console": "Allows to bootstrap a CLI command.",
+        "remi-san/transaction-manager": "Allows to make a consumer transactional using a transaction manager"
     }
 }

--- a/src/Transactional/TransactionalConsumer.php
+++ b/src/Transactional/TransactionalConsumer.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Burrow\Transactional;
+
+use Burrow\Exception\ConsumerException;
+use Burrow\QueueConsumer;
+use RemiSan\TransactionManager\Exception\BeginException;
+use RemiSan\TransactionManager\Transactional;
+
+class TransactionalConsumer
+{
+    /**
+     * @var QueueConsumer
+     */
+    private $consumer;
+
+    /**
+     * @var Transactional
+     */
+    private $transactionManager;
+
+    /**
+     * Constructor
+     *
+     * @param QueueConsumer $consumer
+     * @param Transactional $transactionManager
+     */
+    public function __construct(QueueConsumer $consumer, Transactional $transactionManager)
+    {
+        $this->consumer = $consumer;
+        $this->transactionManager = $transactionManager;
+    }
+
+    /**
+     * Consumes a message.
+     *
+     * @param  string $message
+     *
+     *
+     * @throws \Exception
+     */
+    public function consume($message)
+    {
+        try {
+            $this->transactionManager->beginTransaction();
+        } catch (BeginException $e) {
+            throw new ConsumerException($e->getMessage(), $e->getCode(), $e);
+        }
+
+        try {
+            $this->consumer->consume($message);
+            $this->transactionManager->commit();
+        } catch (\Exception $e) {
+            $this->transactionManager->rollback();
+            throw $e;
+        }
+    }
+}

--- a/tests/Transactional/TransactionalConsumerTest.php
+++ b/tests/Transactional/TransactionalConsumerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Burrow\tests\Transactional;
+
+use Burrow\Exception\ConsumerException;
+use Burrow\QueueConsumer;
+use Burrow\Transactional\TransactionalConsumer;
+use RemiSan\TransactionManager\Exception\BeginException;
+use RemiSan\TransactionManager\Transactional;
+
+class TransactionalConsumerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var QueueConsumer
+     */
+    private $consumer;
+
+    /**
+     * @var Transactional
+     */
+    private $transactionManager;
+
+    protected function tearDown()
+    {
+        \Mockery::close();
+    }
+
+    protected function setUp()
+    {
+        $this->consumer = \Mockery::mock(QueueConsumer::class);
+        $this->transactionManager = \Mockery::mock(Transactional::class);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_throw_ConsumerExeption_if_beginTransaction_fails()
+    {
+        $this->setExpectedException(ConsumerException::class);
+
+        $this->transactionManager
+            ->shouldReceive('beginTransaction')
+            ->andThrow(BeginException::class);
+
+        $consumer = new TransactionalConsumer($this->consumer, $this->transactionManager);
+
+        $consumer->consume('test');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_commit_if_consumer_consumes_normally()
+    {
+        $this->transactionManager->shouldReceive('beginTransaction');
+        $this->transactionManager->shouldReceive('commit');
+
+        $this->consumer->shouldReceive('consume');
+
+        $consumer = new TransactionalConsumer($this->consumer, $this->transactionManager);
+
+        $consumer->consume('test');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_rollback_if_consumer_throws_exception()
+    {
+        $this->setExpectedException(\Exception::class);
+
+        $this->transactionManager->shouldReceive('beginTransaction');
+        $this->transactionManager->shouldReceive('commit')->never();
+        $this->transactionManager->shouldReceive('rollback');
+
+        $this->consumer->shouldReceive('consume')->andThrow(\Exception::class);
+
+        $consumer = new TransactionalConsumer($this->consumer, $this->transactionManager);
+
+        $consumer->consume('test');
+    }
+}


### PR DESCRIPTION
Allows to consume inside a transaction.

First implementation was just about a DB transaction, but I wanted a little more, so I used a transaction manager.

The tx manager is my own implementation, no other implementation of such being found on github. You can review it if you want too ([https://github.com/remi-san/transaction-manager](https://github.com/remi-san/transaction-manager)).

Tell me what you think of it.